### PR TITLE
Add SQS event type

### DIFF
--- a/events/aws/sqs.json
+++ b/events/aws/sqs.json
@@ -1,0 +1,36 @@
+{
+    "Records": [
+        {
+            "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
+            "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+            "body": "test",
+            "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "1545082649183",
+                "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+                "ApproximateFirstReceiveTimestamp": "1545082649185"
+            },
+            "messageAttributes": {},
+            "md5OfBody": "098f6bcd4621d373cade4e832627b4f6",
+            "eventSource": "aws:sqs",
+            "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+            "awsRegion": "us-east-2"
+        },
+        {
+            "messageId": "2e1424d4-f796-459a-8184-9c92662be6da",
+            "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
+            "body": "test",
+            "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "1545082650636",
+                "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+                "ApproximateFirstReceiveTimestamp": "1545082650649"
+            },
+            "messageAttributes": {},
+            "md5OfBody": "098f6bcd4621d373cade4e832627b4f6",
+            "eventSource": "aws:sqs",
+            "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+            "awsRegion": "us-east-2"
+        }
+    ]
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const get = require('lodash/get');
 
 const dictionary = {
   'aws:sns': require('../events/aws/sns.json'),
+  'aws:sqs': require('../events/aws/sqs.json'),
   'aws:apiGateway': require('../events/aws/apiGateway.json'),
   'aws:scheduled': require('../events/aws/scheduled.json'),
   'aws:s3': require('../events/aws/s3.json'),

--- a/tests/index.js
+++ b/tests/index.js
@@ -23,6 +23,24 @@ describe('#AWS Event Mocks()', function () {
     });
   });
 
+  describe('createSqsEvent()', function () {
+    it('should return SQS mocked event', function () {
+      const event = createEvent({
+        template: 'aws:sqs',
+        merge: {
+          Records: [{
+            body: {
+              foo: 'bar'
+            }
+          }],
+        },
+      });
+
+      expect(event.Records[0].body.foo).to.equal('bar');
+      expect(event.Records[0].eventSource).to.equal('aws:sqs');
+    });
+  });
+
   describe('createApigEvent()', function () {
     it('should return APIG mocked event', function () {
       const event = createEvent({


### PR DESCRIPTION
This PR adds SQS as an event type. I copied it from here:
https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
which is used by DefinitelyTyped: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/index.d.ts#L888