### PR TITLE
We probably only need one event here

### DIFF
--- a/events/aws/sqs.json
+++ b/events/aws/sqs.json
@@ -15,22 +15,6 @@
             "eventSource": "aws:sqs",
             "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
             "awsRegion": "us-east-2"
-        },
-        {
-            "messageId": "2e1424d4-f796-459a-8184-9c92662be6da",
-            "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
-            "body": "test",
-            "attributes": {
-                "ApproximateReceiveCount": "1",
-                "SentTimestamp": "1545082650636",
-                "SenderId": "AIDAIENQZJOLO23YVJ4VO",
-                "ApproximateFirstReceiveTimestamp": "1545082650649"
-            },
-            "messageAttributes": {},
-            "md5OfBody": "098f6bcd4621d373cade4e832627b4f6",
-            "eventSource": "aws:sqs",
-            "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
-            "awsRegion": "us-east-2"
         }
     ]
 }


### PR DESCRIPTION
I initially thought it would be best to have multiple records, but now I realize that the library was not designed to do this. I'll remove it for now, until support is added.