### PR TITLE
Use fs.readfileSync over require

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,14 +5,19 @@
 const merge = require('lodash/merge');
 const has = require('lodash/has');
 const get = require('lodash/get');
+const fs = require('fs');
+const path = require('path');
+
 
 const dictionary = {
-  'aws:sns': require('../events/aws/sns.json'),
-  'aws:sqs': require('../events/aws/sqs.json'),
-  'aws:apiGateway': require('../events/aws/apiGateway.json'),
-  'aws:scheduled': require('../events/aws/scheduled.json'),
-  'aws:s3': require('../events/aws/s3.json'),
-  'aws:kinesis': require('../events/aws/kinesis.json'),
+  'aws:sns': fs.readFileSync(path.resolve(__dirname, '../events/aws/sns.json'), 'utf-8'),
+  'aws:sqs': fs.readFileSync(path.resolve(__dirname, '../events/aws/sqs.json'), 'utf-8'),
+  'aws:apiGateway': fs.readFileSync(
+      path.resolve(__dirname, '../events/aws/apiGateway.json'), 'utf-8'),
+  'aws:scheduled': fs.readFileSync(
+      path.resolve(__dirname, '../events/aws/scheduled.json'), 'utf-8'),
+  'aws:s3': fs.readFileSync(path.resolve(__dirname, '../events/aws/s3.json'), 'utf-8'),
+  'aws:kinesis': fs.readFileSync(path.resolve(__dirname, '../events/aws/kinesis.json'), 'utf-8'),
 };
 
 module.exports = function createEvent(config) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,14 +10,18 @@ const path = require('path');
 
 
 const dictionary = {
-  'aws:sns': fs.readFileSync(path.resolve(__dirname, '../events/aws/sns.json'), 'utf-8'),
-  'aws:sqs': fs.readFileSync(path.resolve(__dirname, '../events/aws/sqs.json'), 'utf-8'),
-  'aws:apiGateway': fs.readFileSync(
-      path.resolve(__dirname, '../events/aws/apiGateway.json'), 'utf-8'),
-  'aws:scheduled': fs.readFileSync(
-      path.resolve(__dirname, '../events/aws/scheduled.json'), 'utf-8'),
-  'aws:s3': fs.readFileSync(path.resolve(__dirname, '../events/aws/s3.json'), 'utf-8'),
-  'aws:kinesis': fs.readFileSync(path.resolve(__dirname, '../events/aws/kinesis.json'), 'utf-8'),
+  'aws:sns': JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../events/aws/sns.json'), 'utf-8')),
+  'aws:sqs': JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../events/aws/sqs.json'), 'utf-8')),
+  'aws:apiGateway': JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../events/aws/apiGateway.json'), 'utf-8')),
+  'aws:scheduled': JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../events/aws/scheduled.json'), 'utf-8')),
+  'aws:s3': JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../events/aws/s3.json'), 'utf-8')),
+  'aws:kinesis': JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../events/aws/kinesis.json'), 'utf-8')),
 };
 
 module.exports = function createEvent(config) {


### PR DESCRIPTION
Hi.

Ran into object caching issues in our test suites due to the usage of require to read the sample mocks as described here.

https://goenning.net/2016/04/14/stop-reading-json-files-with-require/

This PR should address the issue